### PR TITLE
#20 Refactor application configuration to remove private key usage an…

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -16,7 +16,6 @@
     "routerAddress": "",
     "wallet": {
       "maxGasLimit": 1000000,
-      "privateKey": "",
       "paymentAddress": "",
       "allowedSimErrors": ["execution reverted", "out of gas"]
     },

--- a/src/main/java/io/hpp/noosphere/agent/config/ApplicationProperties.java
+++ b/src/main/java/io/hpp/noosphere/agent/config/ApplicationProperties.java
@@ -110,192 +110,209 @@ public class ApplicationProperties {
         @JsonProperty("Hub")
         @NestedConfigurationProperty
         private Hub hub;
-    }
 
-    @Setter
-    @Getter
-    @Validated
-    public static class NoosphereServer {
-
-        @NotNull
-        @Min(1)
-        @Max(65535)
-        private Integer port = 8080;
-
-        @Valid
-        @NotNull
-        @NestedConfigurationProperty
-        private RateLimit rateLimit = new RateLimit();
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class RateLimit {
-
-        @NotNull
-        @Positive
-        private Integer numRequests = 100;
-
-        @NotNull
-        @Positive
-        private Integer period = 60;
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class Chain {
-
-        @NotNull
-        private Boolean enabled = true;
-
-        private String rpcUrl = "http://localhost:8545";
-
-        @NotNull
-        private Long trailHeadBlocks = 10L;
-
-        private String routerAddress;
-
-        @Valid
-        @NestedConfigurationProperty
-        private Wallet wallet;
-
-        @Valid
-        @NotNull
-        @NestedConfigurationProperty
-        private SnapshotSync snapshotSync = new SnapshotSync();
-
-        private ConnectionConfig connection = new ConnectionConfig();
-
-        private GasConfig gasConfig = new GasConfig();
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class Wallet {
-
-        @NotNull
-        @Positive
-        private Integer maxGasLimit = 1000000;
-
-        private String privateKey;
-        private String paymentAddress;
-
-        @NotNull
-        private List<String> allowedSimErrors = new ArrayList<>();
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class SnapshotSync {
-
-        private Long sleep = (long) 1.0;
-        private Integer batchSize = 100;
-        private Integer startingSubId = 0;
-        private String syncPeriod = "3000";
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class ConnectionConfig {
-
-        private Integer timeout;
-        private Integer readTimeout;
-        private Integer writeTimeout;
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class GasConfig {
-
-        private Double priceMultiplier;
-        private Double limitMultiplier;
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class Docker {
-
-        private String username;
-        private String password;
-    }
-
-    @Setter
-    @Getter
-    @Validated
-    public static class NoosphereContainer {
-
-        @NotBlank
-        private String id;
-
-        @NotBlank
-        private String image;
-
-        @NotBlank
-        private String url;
-
-        @NotBlank
-        private String bearer;
-
-        @NotNull
-        @Min(1)
-        @Max(65535)
-        private Integer port;
-
-        @NotNull
-        private Boolean gpu = false;
-
-        @NotNull
-        private Map<String, Integer> acceptedPayments = new HashMap<>();
-
-        private String description;
-        private String command;
-
-        private String verifierAddress;
-
-        @NotNull
-        private Map<String, Object> env = new HashMap<>();
-
-        @NotNull
-        private List<String> volumes = new ArrayList<>();
-    }
-
-    @Setter
-    @Getter
-    public static class Hub {
-
+        @Setter
         @Getter
-        private Boolean register;
+        @Validated
+        public static class NoosphereServer {
 
-        private String url;
+            @NotNull
+            @Min(1)
+            @Max(65535)
+            private Integer port = 8080;
 
-        @Valid
-        @NestedConfigurationProperty
-        private KeepAlive keepAlive = new KeepAlive();
-    }
+            @Valid
+            @NotNull
+            @NestedConfigurationProperty
+            private RateLimit rateLimit = new RateLimit();
 
-    @Setter
-    @Getter
-    public static class KeepAlive {
+            @Setter
+            @Getter
+            @Validated
+            public static class RateLimit {
 
-        private boolean enabled;
-        private long intervalMs = 60000; // Default to 1 minute
-        private long batchSize = 100;
-    }
+                @NotNull
+                @Positive
+                private Integer numRequests = 100;
 
-    @Setter
-    @Getter
-    public static class Agent {
+                @NotNull
+                @Positive
+                private Integer period = 60;
+            }
+        }
 
-        private String name;
-        private String publicEndpoint;
-        private String apiKey;
-        private String email;
+        @Setter
+        @Getter
+        @Validated
+        public static class Chain {
+
+            @NotNull
+            private Boolean enabled = true;
+
+            private String rpcUrl = "http://localhost:8545";
+
+            @NotNull
+            private Long trailHeadBlocks = 10L;
+
+            private String routerAddress;
+
+            @Valid
+            @NestedConfigurationProperty
+            private Wallet wallet;
+
+            @Valid
+            @NotNull
+            @NestedConfigurationProperty
+            private SnapshotSync snapshotSync = new SnapshotSync();
+
+            private ConnectionConfig connection = new ConnectionConfig();
+
+            private GasConfig gasConfig = new GasConfig();
+
+            @Setter
+            @Getter
+            @Validated
+            public static class Wallet {
+
+                @NotNull
+                @Positive
+                private Integer maxGasLimit = 1000000;
+
+                private String paymentAddress;
+
+                @NotNull
+                private final Keystore keystore = new Keystore();
+
+                private List<String> allowedSimErrors = new ArrayList<>();
+
+                @Getter
+                @Setter
+                public static class Keystore {
+
+                    private String path;
+                    private String password;
+                    private final Keys keys = new Keys();
+
+                    @Getter
+                    @Setter
+                    public static class Keys {
+
+                        private String eth;
+                    }
+                }
+            }
+
+            @Setter
+            @Getter
+            @Validated
+            public static class SnapshotSync {
+
+                private Long sleep = (long) 1.0;
+                private Integer batchSize = 100;
+                private Integer startingSubId = 0;
+                private String syncPeriod = "3000";
+            }
+
+            @Setter
+            @Getter
+            @Validated
+            public static class ConnectionConfig {
+
+                private Integer timeout;
+                private Integer readTimeout;
+                private Integer writeTimeout;
+            }
+
+            @Setter
+            @Getter
+            @Validated
+            public static class GasConfig {
+
+                private Double priceMultiplier;
+                private Double limitMultiplier;
+            }
+        }
+
+        @Setter
+        @Getter
+        @Validated
+        public static class Docker {
+
+            private String username;
+            private String password;
+        }
+
+        @Setter
+        @Getter
+        @Validated
+        public static class NoosphereContainer {
+
+            @NotBlank
+            private String id;
+
+            @NotBlank
+            private String image;
+
+            @NotBlank
+            private String url;
+
+            @NotBlank
+            private String bearer;
+
+            @NotNull
+            @Min(1)
+            @Max(65535)
+            private Integer port;
+
+            @NotNull
+            private Boolean gpu = false;
+
+            @NotNull
+            private Map<String, Integer> acceptedPayments = new HashMap<>();
+
+            private String description;
+            private String command;
+
+            private String verifierAddress;
+
+            @NotNull
+            private Map<String, Object> env = new HashMap<>();
+
+            @NotNull
+            private List<String> volumes = new ArrayList<>();
+        }
+
+        @Setter
+        @Getter
+        public static class Hub {
+
+            @Getter
+            private Boolean register;
+
+            private String url;
+
+            @Valid
+            @NestedConfigurationProperty
+            private KeepAlive keepAlive = new KeepAlive();
+
+            @Setter
+            @Getter
+            public static class KeepAlive {
+
+                private boolean enabled;
+                private long intervalMs = 60000; // Default to 1 minute
+                private long batchSize = 100;
+            }
+        }
+
+        @Setter
+        @Getter
+        public static class Agent {
+
+            private String name;
+            private String publicEndpoint;
+            private String apiKey;
+            private String email;
+        }
     }
 }

--- a/src/main/java/io/hpp/noosphere/agent/config/Constants.java
+++ b/src/main/java/io/hpp/noosphere/agent/config/Constants.java
@@ -16,6 +16,8 @@ public final class Constants {
 
     public static final String ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
+    public static final String KEYSTORE_TYPE = "PKCS12";
+
     public static final String FULL_DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
     public static final String KAKAO_PAY_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     public static final String TOSS_PAY_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssXXX";

--- a/src/main/java/io/hpp/noosphere/agent/service/ComputationService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/ComputationService.java
@@ -293,11 +293,11 @@ public class ComputationService {
      */
     public CompletableFuture<Map<String, Map<String, Object>>> collectServiceResources(Optional<String> modelId) {
         ParameterizedTypeReference<Map<String, Object>> mapType = new ParameterizedTypeReference<Map<String, Object>>() {};
-        List<ApplicationProperties.NoosphereContainer> configs = containerManager.getConfigs();
+        List<ApplicationProperties.NoosphereConfig.NoosphereContainer> configs = containerManager.getConfigs();
 
         Map<String, CompletableFuture<Map<String, Object>>> futures = new HashMap<>();
 
-        for (ApplicationProperties.NoosphereContainer config : configs) {
+        for (ApplicationProperties.NoosphereConfig.NoosphereContainer config : configs) {
             String url = modelId
                 .map(id -> String.format("http://%s:%d/service-resources?model_id=%s", host, config.getPort(), id))
                 .orElse(String.format("http://%s:%d/service-resources", host, config.getPort()));

--- a/src/main/java/io/hpp/noosphere/agent/service/ContainerManagerService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/ContainerManagerService.java
@@ -35,8 +35,8 @@ public class ContainerManagerService {
     private Double startupWait;
     private Boolean managed;
     private DockerClient dockerClient;
-    private List<ApplicationProperties.NoosphereContainer> configs;
-    private ApplicationProperties.Docker credentials;
+    private List<ApplicationProperties.NoosphereConfig.NoosphereContainer> configs;
+    private ApplicationProperties.NoosphereConfig.Docker credentials;
 
     // Maps for dynamic port mapping
     private final Map<String, Integer> portMappings = new ConcurrentHashMap<>();
@@ -72,7 +72,7 @@ public class ContainerManagerService {
     }
 
     public List<String> getActiveContainers() {
-        return configs.stream().map(ApplicationProperties.NoosphereContainer::getId).collect(Collectors.toList());
+        return configs.stream().map(ApplicationProperties.NoosphereConfig.NoosphereContainer::getId).collect(Collectors.toList());
     }
 
     /**
@@ -185,7 +185,7 @@ public class ContainerManagerService {
     /**
      * Add container configuration
      */
-    public void addConfig(ApplicationProperties.NoosphereContainer config) {
+    public void addConfig(ApplicationProperties.NoosphereConfig.NoosphereContainer config) {
         if (configs == null) {
             configs = new ArrayList<>();
         }
@@ -193,7 +193,7 @@ public class ContainerManagerService {
         log.info("Added container config: {}", config.getId());
     }
 
-    public List<ApplicationProperties.NoosphereContainer> getConfigs() {
+    public List<ApplicationProperties.NoosphereConfig.NoosphereContainer> getConfigs() {
         return configs != null ? configs : new ArrayList<>();
     }
 
@@ -219,7 +219,7 @@ public class ContainerManagerService {
             .stream()
             .filter(config -> config.getId().equals(containerId))
             .findFirst()
-            .map(ApplicationProperties.NoosphereContainer::getPort)
+            .map(ApplicationProperties.NoosphereConfig.NoosphereContainer::getPort)
             .orElse(null);
     }
 
@@ -237,7 +237,7 @@ public class ContainerManagerService {
             .stream()
             .filter(config -> config.getId().equals(containerId))
             .findFirst()
-            .map(ApplicationProperties.NoosphereContainer::getUrl)
+            .map(ApplicationProperties.NoosphereConfig.NoosphereContainer::getUrl)
             .orElse(null);
     }
 
@@ -255,7 +255,7 @@ public class ContainerManagerService {
             .stream()
             .filter(config -> config.getId().equals(containerId))
             .findFirst()
-            .map(ApplicationProperties.NoosphereContainer::getBearer)
+            .map(ApplicationProperties.NoosphereConfig.NoosphereContainer::getBearer)
             .orElse(null);
     }
 
@@ -292,7 +292,7 @@ public class ContainerManagerService {
         }
 
         try {
-            for (ApplicationProperties.NoosphereContainer config : configs) {
+            for (ApplicationProperties.NoosphereConfig.NoosphereContainer config : configs) {
                 String containerName = "noosphere-" + config.getId();
 
                 if (!isContainerHealthy(containerName)) {
@@ -350,7 +350,7 @@ public class ContainerManagerService {
      * Pull images
      */
     private void pullImages() {
-        for (ApplicationProperties.NoosphereContainer config : configs) {
+        for (ApplicationProperties.NoosphereConfig.NoosphereContainer config : configs) {
             try {
                 log.info("Pulling image: {}", config.getImage());
                 dockerClient
@@ -370,7 +370,7 @@ public class ContainerManagerService {
      * Clean up existing containers
      */
     private void pruneContainers() {
-        for (ApplicationProperties.NoosphereContainer config : configs) {
+        for (ApplicationProperties.NoosphereConfig.NoosphereContainer config : configs) {
             String containerName = "noosphere-" + config.getId();
             try {
                 List<Container> existingContainers = dockerClient
@@ -393,7 +393,7 @@ public class ContainerManagerService {
      * Run containers
      */
     private void runContainers() {
-        for (ApplicationProperties.NoosphereContainer config : configs) {
+        for (ApplicationProperties.NoosphereConfig.NoosphereContainer config : configs) {
             try {
                 createAndStartContainer(config);
             } catch (Exception e) {
@@ -405,7 +405,7 @@ public class ContainerManagerService {
     /**
      * Create and start container (apply dynamic port mapping)
      */
-    private void createAndStartContainer(ApplicationProperties.NoosphereContainer config) {
+    private void createAndStartContainer(ApplicationProperties.NoosphereConfig.NoosphereContainer config) {
         String containerName = "noosphere-" + config.getId();
 
         try {
@@ -482,7 +482,7 @@ public class ContainerManagerService {
     /**
      * Update dynamic port mapping information
      */
-    private void updateDynamicPortMappings(ApplicationProperties.NoosphereContainer config, String containerId) {
+    private void updateDynamicPortMappings(ApplicationProperties.NoosphereConfig.NoosphereContainer config, String containerId) {
         try {
             InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(containerId).exec();
 
@@ -582,7 +582,7 @@ public class ContainerManagerService {
     /**
      * Restart container
      */
-    private void restartContainer(ApplicationProperties.NoosphereContainer config) {
+    private void restartContainer(ApplicationProperties.NoosphereConfig.NoosphereContainer config) {
         String containerName = "noosphere-" + config.getId();
 
         try {
@@ -617,7 +617,7 @@ public class ContainerManagerService {
     /**
      * Force recreate container (remove existing container and create new one)
      */
-    private void recreateContainer(ApplicationProperties.NoosphereContainer config) {
+    private void recreateContainer(ApplicationProperties.NoosphereConfig.NoosphereContainer config) {
         restartContainer(config); // Currently uses the same logic as restart
     }
 

--- a/src/main/java/io/hpp/noosphere/agent/service/HubKeepAliveService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/HubKeepAliveService.java
@@ -43,7 +43,7 @@ public class HubKeepAliveService {
      */
     @Scheduled(fixedDelayString = "${application.noosphere.hub.keep-alive.interval-ms}")
     public void sendKeepAlive() {
-        ApplicationProperties.Hub hubConfig = applicationProperties.getNoosphere().getHub();
+        ApplicationProperties.NoosphereConfig.Hub hubConfig = applicationProperties.getNoosphere().getHub();
         if (hubConfig == null || !hubConfig.getKeepAlive().isEnabled() || agentService.getRegisteredAgent() == null) {
             // Keep-alive is disabled, do nothing.
             return;

--- a/src/main/java/io/hpp/noosphere/agent/service/HubRegistrationService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/HubRegistrationService.java
@@ -46,7 +46,7 @@ public class HubRegistrationService {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void registerWithHubOnStartup() {
-        ApplicationProperties.Hub hubConfig = noosphereConfig.getHub();
+        ApplicationProperties.NoosphereConfig.Hub hubConfig = noosphereConfig.getHub();
         if (hubConfig == null || !hubConfig.getRegister()) {
             log.info("Hub registration is disabled in the configuration.");
             return;
@@ -93,7 +93,7 @@ public class HubRegistrationService {
      * Registers the agent by sending its information to the hub via a POST request.
      */
     private void registerNewAgent(String hubUrl, String agentAddress) {
-        ApplicationProperties.Agent agentConfig = noosphereConfig.getAgent();
+        ApplicationProperties.NoosphereConfig.Agent agentConfig = noosphereConfig.getAgent();
 
         if (agentConfig.getApiKey() == null || agentConfig.getEmail() == null) {
             log.warn("Agent's name, apiKey, or email is not configured. Skipping hub registration.");

--- a/src/main/java/io/hpp/noosphere/agent/service/blockchain/BlockchainListener.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/blockchain/BlockchainListener.java
@@ -38,7 +38,7 @@ public class BlockchainListener implements ApplicationListener<ApplicationReadyE
     private final Web3SubscriptionBatchReaderService web3BatchReader;
     private final RequestValidatorService requestValidatorService;
     private final BlockChainService blockChainService;
-    private final ApplicationProperties.Chain properties;
+    private final ApplicationProperties.NoosphereConfig.Chain properties;
     private final ContainerLookupService containerLookupService;
 
     private final AtomicLong lastSyncedBlock = new AtomicLong(0);

--- a/src/main/java/io/hpp/noosphere/agent/service/blockchain/KeystoreService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/blockchain/KeystoreService.java
@@ -1,0 +1,116 @@
+package io.hpp.noosphere.agent.service.blockchain;
+
+import static io.hpp.noosphere.agent.config.Constants.KEYSTORE_TYPE;
+
+import io.hpp.noosphere.agent.config.ApplicationProperties;
+import io.hpp.noosphere.agent.service.util.CommonUtil;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.Base64;
+import javax.crypto.SecretKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Service;
+import org.web3j.crypto.Credentials;
+
+@Service
+public class KeystoreService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeystoreService.class);
+
+    private final ApplicationProperties applicationProperties;
+    private KeyStore keyStore;
+
+    public KeystoreService(ApplicationProperties applicationProperties) {
+        this.applicationProperties = applicationProperties;
+        try {
+            this.keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+            try (
+                InputStream fis = Files.newInputStream(
+                    Path.of(applicationProperties.getNoosphere().getChain().getWallet().getKeystore().getPath())
+                )
+            ) {
+                keyStore.load(fis, applicationProperties.getNoosphere().getChain().getWallet().getKeystore().getPassword().toCharArray());
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to load the keystore. This is a fatal error for KeystoreService.", e);
+            throw new IllegalStateException("Could not initialize KeystoreService", e);
+        }
+    }
+
+    private String getKeyPassword(String keyAlias) {
+        return applicationProperties.getNoosphere().getChain().getWallet().getKeystore().getPassword();
+    }
+
+    public String getSecretKey(String keyAlias) {
+        try {
+            String keyPassword = getKeyPassword(keyAlias);
+            if (CommonUtil.isValid(keyPassword) && keyStore != null) {
+                KeyStore.ProtectionParameter entryPassword = new KeyStore.PasswordProtection(keyPassword.toCharArray());
+
+                KeyStore.Entry entry = keyStore.getEntry(keyAlias, entryPassword);
+
+                if (!(entry instanceof KeyStore.SecretKeyEntry)) {
+                    LOG.debug("Error: Entry with alias '" + keyAlias + "' is not a SecretKeyEntry.");
+                    return null;
+                }
+
+                KeyStore.SecretKeyEntry skEntry = (KeyStore.SecretKeyEntry) entry;
+                SecretKey secretKey = skEntry.getSecretKey();
+
+                byte[] keyBytes = secretKey.getEncoded();
+                return new String(Base64.getDecoder().decode(keyBytes), StandardCharsets.UTF_8);
+            }
+        } catch (Exception e) {
+            LOG.error("Failed to getSecretKey " + keyAlias, e);
+        }
+        return null;
+    }
+
+    /**
+     * Retrieves the private key for a given alias and creates Web3j Credentials.
+     *
+     * @param keyAlias The alias of the key in the keystore.
+     * @return The {@link Credentials} object for the given key.
+     * @throws IllegalStateException if the key is not found or is not valid.
+     */
+    @NonNull
+    public Credentials getCredentials(String keyAlias) {
+        try {
+            if (keyAlias == null || keyAlias.trim().isEmpty()) {
+                throw new IllegalArgumentException("Key alias cannot be null or empty");
+            }
+
+            // Check if the alias exists in the keystore
+            if (!keyStore.containsAlias(keyAlias)) {
+                throw new IllegalStateException("Key alias '" + keyAlias + "' not found in keystore");
+            }
+
+            String privateKey = this.getSecretKey(keyAlias);
+            if (privateKey == null || privateKey.trim().isEmpty()) {
+                throw new IllegalStateException("Failed to retrieve private key for alias: " + keyAlias);
+            }
+
+            // Validate private key format (should be 64 hex characters or start with 0x)
+            String cleanKey = privateKey.trim();
+            if (cleanKey.startsWith("0x")) {
+                cleanKey = cleanKey.substring(2);
+            }
+
+            if (cleanKey.length() != 64) {
+                throw new IllegalStateException(
+                    "Invalid private key format for alias: " + keyAlias + ". Expected 64 hex characters, got: " + cleanKey.length()
+                );
+            }
+
+            return Credentials.create(privateKey);
+        } catch (Exception e) {
+            LOG.error("Failed to create credentials for alias: {}", keyAlias, e);
+            throw new RuntimeException("Failed to load credentials from keystore for alias: " + keyAlias, e);
+        }
+    }
+}

--- a/src/main/java/io/hpp/noosphere/agent/service/blockchain/WalletService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/blockchain/WalletService.java
@@ -31,7 +31,7 @@ public class WalletService {
 
     private final Web3j web3j;
     private final Web3DelegateeCoordinatorService coordinatorService;
-    private final ApplicationProperties.Wallet walletProperties;
+    private final ApplicationProperties.NoosphereConfig.Chain.Wallet walletProperties;
     private final Credentials credentials;
     private final TransactionManager transactionManager;
     private final TransactionReceiptProcessor transactionReceiptProcessor;
@@ -43,16 +43,13 @@ public class WalletService {
         Web3j web3j,
         Web3DelegateeCoordinatorService coordinatorService,
         NoosphereConfigService noosphereConfigService,
+        Credentials credentials,
         BigInteger chainId
     ) throws IOException {
         walletProperties = noosphereConfigService.getActiveConfig().getChain().getWallet();
-
-        if (walletProperties.getPrivateKey() == null || !walletProperties.getPrivateKey().startsWith("0x")) {
-            throw new IllegalArgumentException("Private key must be provided and be 0x-prefixed.");
-        }
         this.coordinatorService = coordinatorService;
         this.web3j = web3j;
-        this.credentials = Credentials.create(walletProperties.getPrivateKey());
+        this.credentials = credentials;
         this.transactionManager = new RawTransactionManager(web3j, credentials, chainId.longValue());
         this.transactionReceiptProcessor = new PollingTransactionReceiptProcessor(web3j, 1000, 15); // Poll every 1s, 15 attempts
 

--- a/src/main/java/io/hpp/noosphere/agent/service/blockchain/web3/Web3RouterService.java
+++ b/src/main/java/io/hpp/noosphere/agent/service/blockchain/web3/Web3RouterService.java
@@ -60,7 +60,7 @@ public class Web3RouterService {
 
     @PostConstruct
     public void init() {
-        ApplicationProperties.Chain chainConfig = noosphereConfigService.getActiveConfig().getChain();
+        ApplicationProperties.NoosphereConfig.Chain chainConfig = noosphereConfigService.getActiveConfig().getChain();
         String routerAddress = chainConfig.getRouterAddress();
 
         if (routerAddress == null || routerAddress.isEmpty()) {
@@ -205,7 +205,7 @@ public class Web3RouterService {
     private void loadContractAddresses() {
         try {
             // First load statically defined contracts from configuration file
-            ApplicationProperties.Chain chainConfig = noosphereConfigService.getActiveConfig().getChain();
+            ApplicationProperties.NoosphereConfig.Chain chainConfig = noosphereConfigService.getActiveConfig().getChain();
 
             if (chainConfig.getRouterAddress() != null && !chainConfig.getRouterAddress().isEmpty()) {
                 contractAddresses.put("Router", chainConfig.getRouterAddress());

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -121,7 +121,6 @@ application:
     chain:
       routerAddress: '0x1234567890123456789012345678901234567890'
       wallet:
-        privateKey: '${WALLET_PRIVATE_KEY:dev-private-key}'
         paymentAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
 
     # 개발 환경 Docker 설정

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -139,7 +139,6 @@ application:
       rpcUrl: ${BLOCKCHAIN_RPC_URL:}
       routerAddress: ${REGISTRY_ADDRESS:}
       wallet:
-        privateKey: ${WALLET_PRIVATE_KEY:}
         paymentAddress: ${PAYMENT_ADDRESS:}
 
     # Production Docker settings

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -268,11 +268,15 @@ application:
       routerAddress: '${REGISTRY_ADDRESS:}'
       wallet:
         maxGasLimit: 1000000
-        privateKey: '${WALLET_PRIVATE_KEY:}'
         paymentAddress: '${PAYMENT_ADDRESS:}'
         allowedSimErrors:
           - 'execution reverted'
           - 'out of gas'
+        keystore:
+          path: '${HPP_KEYSTORE_PATH}'
+          password: '${HPP_KEYSTORE_PASSWORD}'
+          keys:
+            eth: '${HPP_ETH_KEY_ALIAS}'
       snapshotSync:
         sleep: 1
         batchSize: 100

--- a/src/main/webapp/app/modules/administration/application-configuration/application-configuration.tsx
+++ b/src/main/webapp/app/modules/administration/application-configuration/application-configuration.tsx
@@ -38,7 +38,6 @@ export const ApplicationConfiguration = () => {
       routerAddress: '',
       wallet: {
         maxGasLimit: 1000000,
-        privateKey: '',
         paymentAddress: '',
         allowedSimErrors: [],
       },

--- a/src/test/java/io/hpp/noosphere/agent/service/blockchain/BlockchainListenerTest.java
+++ b/src/test/java/io/hpp/noosphere/agent/service/blockchain/BlockchainListenerTest.java
@@ -58,9 +58,10 @@ class BlockchainListenerTest {
     @BeforeEach
     void setUp() throws IOException {
         // Mock ApplicationProperties
-        ApplicationProperties.Chain chainProps = new ApplicationProperties.Chain();
+        ApplicationProperties.NoosphereConfig.Chain chainProps = new ApplicationProperties.NoosphereConfig.Chain();
         chainProps.setTrailHeadBlocks(1L);
-        ApplicationProperties.SnapshotSync snapshotSyncProps = new ApplicationProperties.SnapshotSync();
+        ApplicationProperties.NoosphereConfig.Chain.SnapshotSync snapshotSyncProps =
+            new ApplicationProperties.NoosphereConfig.Chain.SnapshotSync();
         snapshotSyncProps.setStartingSubId(5);
         snapshotSyncProps.setBatchSize(100);
         snapshotSyncProps.setSleep(100L);


### PR DESCRIPTION
…d introduce keystore integration

- Replace `privateKey` with `keystore` in `ApplicationProperties` for enhanced security.
- Add `KeystoreService` to centralize credentials management, including secure key retrieval.
- Update services (`WalletService`, `ComputationService`, `ContainerManagerService`, etc.) to utilize keystore-based credentials.
- Refactor configuration structure (`NoosphereConfig`) for better organization, including nested classes.
- Remove hardcoded private keys and adapt tests and configuration files for keystore usage.